### PR TITLE
Fix non-passing phpcs tests.

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -24,8 +24,6 @@
 
 namespace tool_deletecourses\privacy;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Privacy implementation for tool_deletecourses.
  *

--- a/classes/task/delete_courses_task.php
+++ b/classes/task/delete_courses_task.php
@@ -23,8 +23,6 @@
 
 namespace tool_deletecourses\task;
 
-defined('MOODLE_INTERNAL') || die;
-
 /**
  * Adhoc task for deleting courses.
  *
@@ -111,7 +109,7 @@ class delete_courses_task extends \core\task\adhoc_task {
             // Guard against multiple workers in cron.
             if ($lock !== false) {
                 if ($coursedb = $DB->get_record('course', array('id' => $course->id))) {
-                    // course integrity check to prevent delete course errors
+                    // Course integrity check to prevent delete course errors.
                     \course_integrity_check($course->id, null, null, true);
                     if (!delete_course($coursedb, false)) {
                         mtrace("Failed to delete course {$course->id}");

--- a/lib.php
+++ b/lib.php
@@ -22,8 +22,6 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Extends the category navigation to show the course deletion tool.
  *

--- a/tests/tool_deletecourses_test.php
+++ b/tests/tool_deletecourses_test.php
@@ -23,6 +23,10 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace tool_deletecourses;
+
+use advanced_testcase;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
@@ -32,10 +36,11 @@ global $CFG;
  *
  * @package    tool_deletecourses
  * @category   test
+ * @coversDefaultClass \tool_deletecourses
  * @copyright  2017 Lafayette College ITS
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_deletecourses_deletecourses_testcase extends advanced_testcase {
+class tool_deletecourses_testcase extends advanced_testcase {
     public function test_delete_course() {
         global $DB;
 


### PR DESCRIPTION
Maybe you want this to have the code prechecks on https://moodle.org/plugins/tool_deletecourses/versions to have a green badge again.